### PR TITLE
Bugfix for issue 30 "profile nav"

### DIFF
--- a/server.js
+++ b/server.js
@@ -35,8 +35,6 @@ const PORT = process.env.PORT ||  8000;
 if (process.env.NODE_ENV ==='development'){
     app. use(morgan('dev'))
 }
-// EJS
-app.set('view engine', 'ejs');
 
 // Middleware
 app.use(express.urlencoded({ extended: true }));

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -5,8 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- css link -->
-    <link rel="stylesheet" href="public/css/reset.css" />
-    <link rel="stylesheet" href="public/css/style.css" />
+    <link rel="stylesheet" href="/css/reset.css" />
+    <link rel="stylesheet" href="/css/style.css" />
     <!-- fonts link -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- css link -->
-    <link rel="stylesheet" href="public/css/reset.css" />
-    <link rel="stylesheet" href="public/css/style.css" />
+    <link rel="stylesheet" href="/css/reset.css" />
+    <link rel="stylesheet" href="/css/style.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css"
     <!-- corrected the title -->
     <title>Login</title>

--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -5,8 +5,8 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <!-- css link -->
-        <link rel="stylesheet" href="public/css/reset.css" />
-        <link rel="stylesheet" href="public/css/style.css" />
+        <link rel="stylesheet" href="/css/reset.css" />
+        <link rel="stylesheet" href="/css/style.css" />
         <!-- fonts link -->
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Once the leading “public” was removed from the stylesheet href file paths, the stylesheets loaded properly and the styled the header’s nav bar. 

I also removed a duplicate line  in the server js file setting the view engine to ejs.